### PR TITLE
Hiding optional overrides values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-url",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-url",
   "description": "A library containing helper classes and UIs to support URL editing in AMF powered URL editor.",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ApiUrlParamsEditorElement.js
+++ b/src/ApiUrlParamsEditorElement.js
@@ -391,11 +391,10 @@ export class ApiUrlParamsEditorElement extends ValidatableMixin(EventsTargetMixi
     if (!hasQueryParameters) {
       return '';
     }
-    const filteredModel = queryModel.filter(this._shouldFilterQueryParam.bind(this));
     return html`
     <div role="heading" aria-level="1" class="form-title">Query parameters</div>
     ${this[showOptionalTemplate]()}
-    ${this[paramsFormTemplate](filteredModel, 'queryModel')}
+    ${this[paramsFormTemplate](queryModel, 'queryModel')}
     ${this[addTemplate]()}
     `;
   }
@@ -441,8 +440,10 @@ export class ApiUrlParamsEditorElement extends ValidatableMixin(EventsTargetMixi
    * @param {string} type
    */
   [itemTemplate](item, index, type) {
+    const { allowHideOptional, _showOptional: showOptional } = this;
+    const hidden = allowHideOptional && !showOptional  && !item.schema.required;
     return html`
-    <div class="form-row form-item">
+    <div class="form-row form-item" ?hidden=${hidden}>
       ${this[paramToggleTemplate](item, index, type)}
       ${this[paramInputTemplate](item, index, type)}
       ${this[paramRemoveTemplate](item, index, type)}

--- a/src/styles/ParamsEditor.styles.js
+++ b/src/styles/ParamsEditor.styles.js
@@ -40,7 +40,7 @@ api-form-item {
 }
 
 :host([compatibility]) api-form-item {
-  margin-bottom: 30px;
+  margin-bottom: 40px;
 }
 
 .form-row {

--- a/test/ApiUrlParamsEditorElement.test.js
+++ b/test/ApiUrlParamsEditorElement.test.js
@@ -3,6 +3,7 @@ import sinon from 'sinon';
 import '../api-url-params-editor.js';
 
 /** @typedef {import('../index').ApiUrlParamsEditorElement} ApiUrlParamsEditorElement */
+/** @typedef {import('@api-components/api-forms').ApiFormItemElement} ApiFormItem */
 
 describe('ApiUrlParamsEditorElement', () => {
   /**
@@ -449,20 +450,22 @@ describe('ApiUrlParamsEditorElement', () => {
       assert.isNotEmpty(element.shadowRoot.querySelectorAll('.params-list .form-row.form-item'));
     });
 
-    it('should not render optional params when switch is off', async () => {
+    it('should hide optional params when switch is off', async () => {
       const model = [{ name: 'x', value: 'y', schema: {} }];
       element.queryModel = model;
       await nextFrame();
       element.shadowRoot.querySelector('anypoint-switch').click();
       await nextFrame();
-      assert.isEmpty(element.shadowRoot.querySelectorAll('.params-list .form-row.form-item'));
+      const formItem = /** @type ApiFormItem */ (element.shadowRoot.querySelector('.params-list .form-row.form-item'));
+      assert.isTrue(formItem.hidden);
     });
 
-    it('should render required params when switch is off', async () => {
+    it('should not hide required params when switch is off', async () => {
       const model = [{ name: 'x', value: 'y', schema: { required: true } }];
       element.queryModel = model;
       await nextFrame();
-      assert.isNotEmpty(element.shadowRoot.querySelectorAll('.params-list .form-row.form-item'));
+      const formItem = /** @type ApiFormItem */ (element.shadowRoot.querySelector('.params-list .form-row.form-item'));
+      assert.isFalse(formItem.hidden);
     });
 
     it('should render switch disabled if there are no optional params', async () => {


### PR DESCRIPTION
Instead of unrendering hidden parameters, only hide them.

Increase spacing between form items in compatibility mode.