### PR TITLE
Allow required query params to be disabled

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-url",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-url",
   "description": "A library containing helper classes and UIs to support URL editing in AMF powered URL editor.",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ApiUrlParamsEditorElement.js
+++ b/src/ApiUrlParamsEditorElement.js
@@ -463,7 +463,7 @@ export class ApiUrlParamsEditorElement extends ValidatableMixin(EventsTargetMixi
   [paramToggleTemplate](item, index, type) {
     const { allowDisableParams } = this;
     const { schema={} } = item;
-    if ((!schema.isCustom && !allowDisableParams) || schema.required) {
+    if (!schema.isCustom && !allowDisableParams) {
       return '';
     }
     const { compatibility, readOnly, disabled } = this;

--- a/test/ApiUrlParamsEditorElement.test.js
+++ b/test/ApiUrlParamsEditorElement.test.js
@@ -422,7 +422,7 @@ describe('ApiUrlParamsEditorElement', () => {
       const model = [{ name: 'x', value: 'y', schema: { required: true } }];
       element.queryModel = model;
       await nextFrame();
-      assert.notExists(element.shadowRoot.querySelector('.params-list anypoint-switch'));
+      assert.exists(element.shadowRoot.querySelector('.params-list anypoint-switch'));
     });
   });
 


### PR DESCRIPTION
We should allow query parameters to be disabled by the user.

For example, when sending parameters for a `oneOf` property in OAS 3, the user needs to be able to not send parameters that are part of different schemas defined by the `oneOf` property.