### PR TITLE
APIC-744 Ensure content updates define focus updates appropriately - fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-url",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-url",
   "description": "A library containing helper classes and UIs to support URL editing in AMF powered URL editor.",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ApiUrlParamsEditorElement.js
+++ b/src/ApiUrlParamsEditorElement.js
@@ -34,6 +34,7 @@ export const removeParamHandler = Symbol('removeParamHandler');
 export const addCustomHandler = Symbol('addCustomHandler');
 export const showOptionalTemplate = Symbol('showOptionalTemplate');
 export const showOptionalHandler = Symbol('showOptionalHandler');
+export const focusLastName = Symbol('focusLastName');
 
 /**
  * An element to render query / uri parameters form from AMF schema
@@ -308,6 +309,23 @@ export class ApiUrlParamsEditorElement extends ValidatableMixin(EventsTargetMixi
   }
 
   /**
+   * Focuses on the last header name filed
+   */
+   [focusLastName]() {
+    const row = this.shadowRoot.querySelector('.params-list > :last-child');
+    if (!row) {
+      return;
+    }
+    try {
+      const node = row.querySelector('.param-name');
+      // @ts-ignore
+      node.focus();
+    } catch (e) {
+      // ...
+    }
+  }
+
+  /**
    * Adds empty custom property to the list.
    */
   addCustom() {
@@ -326,6 +344,8 @@ export class ApiUrlParamsEditorElement extends ValidatableMixin(EventsTargetMixi
     if (this.allowHideOptional && !this._showOptional) {
       this._showOptional = true;
     }
+
+    setTimeout(() => this[focusLastName]());
   }
 
   /**

--- a/src/ApiUrlParamsEditorElement.js
+++ b/src/ApiUrlParamsEditorElement.js
@@ -309,7 +309,7 @@ export class ApiUrlParamsEditorElement extends ValidatableMixin(EventsTargetMixi
   }
 
   /**
-   * Focuses on the last header name filed
+   * Focuses on the last param name filed
    */
    [focusLastName]() {
     const row = this.shadowRoot.querySelector('.params-list > :last-child');

--- a/test/ApiUrlParamsEditorElement.test.js
+++ b/test/ApiUrlParamsEditorElement.test.js
@@ -264,6 +264,18 @@ describe('ApiUrlParamsEditorElement', () => {
       assert.lengthOf(element.queryModel, 1);
     });
 
+    it('should put focus in new input field when execute addCustom method', async () => {
+      const inputNotExisting = /** @type HTMLInputElement */ (element.shadowRoot.querySelector('.param-name'));
+      assert.isNull(inputNotExisting);
+
+      element.addCustom();
+      await aTimeout(100);
+
+      const inputAdded = /** @type HTMLInputElement */ (element.shadowRoot.querySelector('.param-name'));
+      assert.isDefined(inputAdded);
+      assert.isTrue(inputAdded.focused);
+    });
+
     it('sets `isCustom` property', () => {
       const button = /** @type HTMLElement */ (element.shadowRoot.querySelector('.add-param'));
       button.click();


### PR DESCRIPTION
### Description
When user activates the "Add" button, new content is added above the "Add" button. The focus does not move to the newly added controls, instead the focus remains on the "Add" button itself.

### UI screenshots with changes 

https://user-images.githubusercontent.com/96145153/152585578-878c1031-4b14-4cfd-99dc-a897e4bce244.mov


#### Issue type
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:

- [x] The created branch follows branching convention: fix/AAP-x/*, feat/AAP-x/*, test/AAP-x/* or chore/AAP-x/*
- [x] The commit messages have the Jira ticket.
- [x] The PR is rebased with base branch.
- [x] I added tests.
- [x] I validated the fix manually.
- [x] I have performed a self-review of my own code
- [ ] This change requires documentation update
- [ ] This change includes library / dependency update.
- [x] My changes generate no new warnings
