### PR TITLE
Fix/w 10839261/missing 0 parameter value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-url",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-url",
   "description": "A library containing helper classes and UIs to support URL editing in AMF powered URL editor.",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ApiUrlEditorElement.d.ts
+++ b/src/ApiUrlEditorElement.d.ts
@@ -208,10 +208,10 @@ export declare class ApiUrlEditorElement extends EventsTargetMixin(ValidatableMi
   _wwwFormUrlEncode(object: ParamsObject[]): string
   
   /**
-   * @param str A key or value to encode as x-www-form-urlencoded.
+   * @param value A key or value to encode as x-www-form-urlencoded.
    * @param replacePlus When set it replaces `%20` with `+`.
    */
-  _wwwFormUrlEncodePiece(str: string, replacePlus: boolean): string;
+  _wwwFormUrlEncodePiece(value: string|number, replacePlus: boolean): string;
 
   /**
    * Updates URI / query parameters model from user input.

--- a/src/ApiUrlEditorElement.js
+++ b/src/ApiUrlEditorElement.js
@@ -507,17 +507,17 @@ export class ApiUrlEditorElement extends EventsTargetMixin(ValidatableMixin(LitE
   }
   
   /**
-   * @param {string} str A key or value to encode as x-www-form-urlencoded.
+   * @param {string|number} value A key or value to encode as x-www-form-urlencoded.
    * @param {boolean} replacePlus When set it replaces `%20` with `+`.
    * @returns {string}
    */
-  _wwwFormUrlEncodePiece(str, replacePlus) {
+  _wwwFormUrlEncodePiece(value, replacePlus) {
     // Spec says to normalize newlines to \r\n and replace %20 spaces with +.
     // jQuery does this as well, so this is likely to be widely compatible.
-    if (!str) {
+    if (typeof value !== 'number' && !value) {
       return '';
     }
-    let result = encodeURIComponent(str.toString().replace(/\r?\n/g, '\r\n'));
+    let result = encodeURIComponent(value.toString().replace(/\r?\n/g, '\r\n'));
     if (replacePlus) {
       result = result.replace(/%20/g, '+');
     }

--- a/test/ApiUrlEditorElement.test.js
+++ b/test/ApiUrlEditorElement.test.js
@@ -827,6 +827,11 @@ describe('ApiUrlEditorElement', () => {
       const result = element._wwwFormUrlEncodePiece('test value', true);
       assert.equal(result, 'test+value');
     });
+
+    it('returns string containing 0 value', () => {
+      const result = element._wwwFormUrlEncodePiece(0, true);
+      assert.equal(result, '0');
+    });
   });
 
   describe('_wwwFormUrlEncode()', () => {


### PR DESCRIPTION
### Description of the bug
Empty parameter in URL when queryParameter value is 0

For example for this query parameter defined in RAML spec:

```
...
queryParameters:
  offset:
  example: 1
  type: number
  format: int
  description: Specify an OFFSET from where to start returning data
  default: 0
```

URL was being populated as `...?offset=&limit=-1` when it should be `...?offset=0&limit=-1`