### PR TITLE
[W-11386481] Remove templates from URI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-url",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-url",
   "description": "A library containing helper classes and UIs to support URL editing in AMF powered URL editor.",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ApiUrlEditorElement.js
+++ b/src/ApiUrlEditorElement.js
@@ -392,13 +392,10 @@ export class ApiUrlEditorElement extends EventsTargetMixin(ValidatableMixin(LitE
     for (let i = 0; i < entries.length; i++) {
       // eslint-disable-next-line prefer-const
       let [name, value] = entries[i];
-      if (!value) {
+      if (value === null || value === undefined) {
         continue;
       }
       value = String(value);
-      if (value.trim() === '') {
-        continue;
-      }
       const { schema={} } = model[i];
       if (!schema.noAutoEncode) {
         if (name[0] === '+' || name[0] === '#') {

--- a/test/ApiUrlEditorElement.test.js
+++ b/test/ApiUrlEditorElement.test.js
@@ -883,4 +883,23 @@ describe('ApiUrlEditorElement', () => {
       await assert.isAccessible(element);
     });
   });
+
+  describe('_applyUriParams()', () => {
+    let element = /** @type ApiUrlEditorElement */ (null);
+    beforeEach(async () => {
+      element = await basicFixture();
+    });
+
+    it('Does nothing when empty model ', () => {
+      const url = element._applyUriParams("/flights/{id}", undefined);
+      assert.equal(url, '/flights/{id}');
+    });
+
+    it('Replaces template with empty value ', () => {
+      const schema = {required: true, isFile: false, isUnion: false, readOnly: false, apiType: 'string'}
+      const model = [{enabled: true, name: "id", schema, value: ''}]
+      const url = element._applyUriParams("/flights/{id}", model);
+      assert.equal(url, '/flights/');
+    });
+  });
 });


### PR DESCRIPTION
Templates should be replaced with empty value in URI if not already filled.
For example, /flights/{id} should be populated as /flights/ when no value defined and /flights/my-id if a value is filled for that parameter.