### PR TITLE
Fix/W-17655986/exchange asset is not able to pass value only false in the request

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -18,7 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04]
-        # os: [ubuntu-18.04, ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -13,46 +13,27 @@ on:
       - main
 jobs:
   test_linux:
-    name: ubuntu
-    runs-on: ubuntu-latest
-    # steps:
-    #   - uses: actions/checkout@v2
-    #   - uses: actions/setup-node@v1
-    #     with:
-    #       node-version: 16
-    #   - uses: microsoft/playwright-github-action@v1
-    #   - uses: actions/cache@v1
-    #     with:
-    #       path: ~/.npm
-    #       key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-    #       restore-keys: |
-    #         ${{ runner.os }}-node-
-    #   - name: Install dependencies
-    #     run: npm ci
-    #   - name: Run tests
-    #     run: npm test
+    name: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04]
+        # os: [ubuntu-18.04, ubuntu-20.04]
+    runs-on: ${{ matrix.os }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
         with:
           node-version: 16
-
+      - uses: microsoft/playwright-github-action@v1
       - uses: actions/cache@v1
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
-
       - name: Install dependencies
-        run: npm install
-
-      - name: Install Playwright dependencies
-        run: npx playwright install --with-deps
-
+        run: npm ci
       - name: Run tests
         run: npm test
   test_win:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -32,29 +32,29 @@ jobs:
     #   - name: Run tests
     #     run: npm test
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
-    - name: Set up Node.js
-      uses: actions/setup-node@v1
-      with:
-        node-version: 16
+      - name: Set up Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
 
-    - uses: actions/cache@v1
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
+      - uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
 
-    - name: Install dependencies
-      run: npm ci
+      - name: Install dependencies
+        run: npm ci
 
-    - name: Install Playwright dependencies
-      run: npx playwright install --with-deps
+      - name: Install Playwright dependencies
+        run: npx playwright install --with-deps
 
-    - name: Run tests
-      run: npm test
+      - name: Run tests
+        run: npm test
   test_win:
     name: "Windows"
     runs-on: windows-latest

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -15,22 +15,46 @@ jobs:
   test_linux:
     name: ubuntu
     runs-on: ubuntu-latest
+    # steps:
+    #   - uses: actions/checkout@v2
+    #   - uses: actions/setup-node@v1
+    #     with:
+    #       node-version: 16
+    #   - uses: microsoft/playwright-github-action@v1
+    #   - uses: actions/cache@v1
+    #     with:
+    #       path: ~/.npm
+    #       key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+    #       restore-keys: |
+    #         ${{ runner.os }}-node-
+    #   - name: Install dependencies
+    #     run: npm ci
+    #   - name: Run tests
+    #     run: npm test
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 16
-      - uses: microsoft/playwright-github-action@v1
-      - uses: actions/cache@v1
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-      - name: Install dependencies
-        run: npm ci
-      - name: Run tests
-        run: npm test
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 16
+
+    - uses: actions/cache@v1
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Install Playwright dependencies
+      run: npx playwright install --with-deps
+
+    - name: Run tests
+      run: npm test
   test_win:
     name: "Windows"
     runs-on: windows-latest
@@ -53,7 +77,7 @@ jobs:
   tag:
     name: "Publishing release"
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
-    needs: 
+    needs:
       - test_linux
       - test_win
     runs-on: ubuntu-latest

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -48,7 +48,7 @@ jobs:
             ${{ runner.os }}-node-
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Install Playwright dependencies
         run: npx playwright install --with-deps

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@api-components/api-url",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@api-components/api-url",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "license": "Apache-2.0",
       "dependencies": {
         "@advanced-rest-client/arc-icons": "^3.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@api-components/api-url",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@api-components/api-url",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "license": "Apache-2.0",
       "dependencies": {
         "@advanced-rest-client/arc-icons": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-url",
   "description": "A library containing helper classes and UIs to support URL editing in AMF powered URL editor.",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-url",
   "description": "A library containing helper classes and UIs to support URL editing in AMF powered URL editor.",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ApiUrlEditorElement.js
+++ b/src/ApiUrlEditorElement.js
@@ -326,7 +326,7 @@ export class ApiUrlEditorElement extends EventsTargetMixin(ValidatableMixin(LitE
     await this.updateComplete;
     this.validate();
   }
-  
+
   /**
    * Creates a map of serialized values from a model.
    * It is a replacement for `iron-form` serialize function which
@@ -349,11 +349,12 @@ export class ApiUrlEditorElement extends EventsTargetMixin(ValidatableMixin(LitE
     });
     return result;
   }
-  
+
   /**
    * Extracts value from the model item.
-   * If the item is required it is always returned (even  if it is empty string).
+   * If the item is required it is always returned (even if it is an empty string).
    * If value is not required and not present then it returns `undefined`.
+   * Ensures boolean values are correctly preserved.
    *
    * @param {AmfFormItem} item Model item
    * @return {string} Model value
@@ -362,8 +363,14 @@ export class ApiUrlEditorElement extends EventsTargetMixin(ValidatableMixin(LitE
     if (item.schema && item.enabled === false) {
       return undefined;
     }
-    const { schema={} } = item;
+
+    const { schema = {} } = item;
     let { value } = item;
+
+    if (schema.isBool) {
+      return value === false ? "false" : "true";
+    }
+
     if (!value && schema.required) {
       if (value !== 0 && value !== false && value !== null) {
         value = '';
@@ -373,6 +380,7 @@ export class ApiUrlEditorElement extends EventsTargetMixin(ValidatableMixin(LitE
         value = undefined;
       }
     }
+
     return value;
   }
 
@@ -421,7 +429,7 @@ export class ApiUrlEditorElement extends EventsTargetMixin(ValidatableMixin(LitE
     }
     return new RegExp(`{${name}}`);
   }
-  
+
   /**
    * Applies query parameters to the URL.
    * Query parameters that are not required by the API spec and don't have value
@@ -489,7 +497,7 @@ export class ApiUrlEditorElement extends EventsTargetMixin(ValidatableMixin(LitE
   }
 
   /**
-   * @param {ParamsObject[]} object The list of objects to encode as x-www-form-urlencoded string. 
+   * @param {ParamsObject[]} object The list of objects to encode as x-www-form-urlencoded string.
    * Each entry should have `name` and `value` properties.
    * @returns {string}
    */
@@ -502,7 +510,7 @@ export class ApiUrlEditorElement extends EventsTargetMixin(ValidatableMixin(LitE
     });
     return pieces.join('&');
   }
-  
+
   /**
    * @param {string|number} value A key or value to encode as x-www-form-urlencoded.
    * @param {boolean} replacePlus When set it replaces `%20` with `+`.
@@ -572,7 +580,7 @@ export class ApiUrlEditorElement extends EventsTargetMixin(ValidatableMixin(LitE
       obj[name] = parts[1];
     }
   }
-  
+
   /**
    * Applies values from the `values` array to the uri parameters which names are in the `names` array.
    * Both lists are ordered list of parameters.

--- a/test/ApiUrlEditorElement.test.js
+++ b/test/ApiUrlEditorElement.test.js
@@ -7,35 +7,35 @@ import { UrlEventTypes } from '../index.js';
 
 describe('ApiUrlEditorElement', () => {
   /**
-   * @return {Promise<ApiUrlEditorElement>} 
+   * @return {Promise<ApiUrlEditorElement>}
    */
   async function basicFixture() {
     return (fixture(html`<api-url-editor></api-url-editor>`));
   }
 
   /**
-   * @return {Promise<ApiUrlEditorElement>} 
+   * @return {Promise<ApiUrlEditorElement>}
    */
   async function requiredFixture() {
     return (fixture(html`<api-url-editor required></api-url-editor>`));
   }
 
   /**
-   * @return {Promise<ApiUrlEditorElement>} 
+   * @return {Promise<ApiUrlEditorElement>}
    */
   async function eventsFixture() {
     return (fixture(html`<api-url-editor baseUri="https://domain.com" endpointPath="/{path}"></api-url-editor>`));
   }
 
   /**
-   * @return {Promise<ApiUrlEditorElement>} 
+   * @return {Promise<ApiUrlEditorElement>}
    */
   async function valueFixture() {
     return (fixture(html`<api-url-editor value="https://domain.com/api/path"></api-url-editor>`));
   }
 
   /**
-   * @return {Promise<ApiUrlEditorElement>} 
+   * @return {Promise<ApiUrlEditorElement>}
    */
   async function invalidFixture() {
     return (fixture(html`<api-url-editor value="https://domain.com/{path}" invalid></api-url-editor>`));
@@ -107,6 +107,50 @@ describe('ApiUrlEditorElement', () => {
       element.queryModel = queryModel;
       const match = element.value.match(/&arrayParameter=/g);
       assert.equal(match.length, 2);
+    });
+  });
+
+  describe('Boolean values in query parameters', () => {
+    let element = /** @type ApiUrlEditorElement */ (null);
+    let queryModel;
+    const TEST_PATH = '/path/{var}';
+
+    beforeEach(async () => {
+      element = await basicFixture();
+      element.baseUri = BASE_URI;
+      element.endpointPath = TEST_PATH;
+      queryModel = [
+        {
+          value: false,
+          name: 'test1',
+          schema: {
+            required: true,
+            inputType: 'boolean',
+            isBool: true
+          }
+        },
+        {
+          value: true,
+          name: 'test2',
+          schema: {
+            required: true,
+            inputType: 'boolean',
+            isBool: true
+          }
+        }
+      ];
+    });
+
+    it('includes boolean false as a query parameter in the URL', () => {
+      element.queryModel = queryModel;
+      const match = element.value.match(/test1=false/g);
+      assert.equal(match.length, 1, 'Boolean false should be included in the URL as "test1=false"');
+    });
+
+    it('includes boolean true as a query parameter in the URL', () => {
+      element.queryModel = queryModel;
+      const match = element.value.match(/&test2=true/g);
+      assert.equal(match.length, 1, 'Boolean true should be included in the URL as "&test2=true"');
     });
   });
 
@@ -902,4 +946,6 @@ describe('ApiUrlEditorElement', () => {
       assert.equal(url, '/flights/');
     });
   });
+
+
 });


### PR DESCRIPTION
### Problem Description

The issue occurred when setting ValueOnly to false in the exchange asset. Despite this configuration, the boolean value was not being recognized and included in the query parameters as expected. Instead, the request was passing an empty value.

This behavior was observed in the getVersionedActionExecution endpoint, where boolean parameters should have been explicitly included in the URL query string.

#### Solution

Updated the _valueFormModelItem method to correctly handle boolean values.
Ensured that when inputType is "boolean", false is explicitly preserved instead of being treated as an empty or undefined value.
Improved the extraction logic to correctly differentiate between required and optional fields while keeping boolean values intact.
#### Impact

Boolean parameters (e.g., false values) are now correctly included in query parameters.
Ensures that APIs relying on boolean query parameters behave as expected.
Prevents unexpected behavior where false values were previously omitted or replaced with an empty string.
#### Testing
Added unit tests to validate that false and true values are correctly passed in query parameters.


### Screenshot in API console with solution and spec attached on the Bug reported

<img width="1726" alt="Screenshot 2025-02-07 at 9 52 16 PM" src="https://github.com/user-attachments/assets/a22d18e8-3f78-416f-9064-913b5256fc58" />
